### PR TITLE
Improve setup and fix build includes

### DIFF
--- a/ForgeEngine/Core/UI/Editor/Frames/Console.cpp
+++ b/ForgeEngine/Core/UI/Editor/Frames/Console.cpp
@@ -1,6 +1,10 @@
 #include "Console.h"
 
-#include <io.h>
+#ifdef _WIN32
+#  include <io.h>
+#else
+#  include <unistd.h>
+#endif
 
 #include "imgui.h"
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ This engine was tested with the clang compiler. Please, to avoid errors, use cla
 
 ### Quick Setup
 
-Execute the `setup.sh` script to configure and build the project:
+Execute the `setup.sh` script to install dependencies, configure and
+build the project:
 
 ```bash
 ./setup.sh
 ```
 
-This script uses Clang by default and will create the build directory and compile the engine using CMake.
+The script attempts to install all required packages using `apt` or `dnf`
+and then configures the build directory and compiles the engine using
+Clang and CMake. If package installation fails (e.g. on systems without
+network access), the script continues and attempts to build with whatever
+dependencies are already available.
 
 ![image](https://github.com/user-attachments/assets/34628e2b-0908-41e6-b0da-bc227d9a0bf8)
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,16 +1,51 @@
 #!/usr/bin/env bash
 
 # Configuration script for ForgeEngine
-# This script sets default compilers and generates the build system.
+# This script installs required dependencies, sets default compilers
+# and generates the build system.
 
 set -e
 
+######################################################################
+# Dependency installation
+######################################################################
+
+# Use sudo when not running as root
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+    SUDO="sudo"
+fi
+
+install_deps() {
+    if command -v apt-get >/dev/null 2>&1; then
+        $SUDO apt-get update || true
+        $SUDO apt-get install -y \
+            clang build-essential cmake ninja-build git \
+            libgl1-mesa-dev libx11-dev libxrandr-dev libxinerama-dev \
+            libxcursor-dev libxi-dev libxkbcommon-dev libwayland-dev xorg-dev || true
+    elif command -v dnf >/dev/null 2>&1; then
+        $SUDO dnf install -y \
+            clang gcc-c++ cmake ninja-build git \
+            mesa-libGL-devel libX11-devel libXrandr-devel \
+            libXinerama-devel libXcursor-devel libXi-devel \
+            libxkbcommon-devel wayland-devel || true
+    else
+        echo "Unsupported package manager. Please install dependencies manually." >&2
+    fi
+}
+
+install_deps
+
+######################################################################
+# Build configuration
+######################################################################
+
 # Default compilers (can be overridden via environment variables)
-export CC=${CC:-/usr/bin/clang}
-export CXX=${CXX:-/usr/bin/clang++}
+export CC="${CC:-clang}"
+export CXX="${CXX:-clang++}"
 
 # Build directory
-BUILD_DIR=${1:-build}
+BUILD_DIR="${1:-build}"
 
 # Use Ninja if available, otherwise default to Unix Makefiles
 if command -v ninja >/dev/null 2>&1; then
@@ -23,4 +58,4 @@ mkdir -p "$BUILD_DIR"
 
 cmake -S . -B "$BUILD_DIR" -G "$GENERATOR" -DCMAKE_BUILD_TYPE=Release
 
-cmake --build "$BUILD_DIR" -j $(nproc)
+cmake --build "$BUILD_DIR" -j "$(nproc)"


### PR DESCRIPTION
## Summary
- allow `setup.sh` to continue when dependency installation fails
- document fallback behavior in README
- fix console build on Linux by including `<unistd.h>` instead of `<io.h>`

## Testing
- `bash setup.sh` *(fails: missing packages and OpenGL not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a597fc648332a63937e1469b4f80