### PR TITLE
Add MeshKey map for Renderer3D batching

### DIFF
--- a/ForgeEngine/Core/Renderer/Renderer3D.cpp
+++ b/ForgeEngine/Core/Renderer/Renderer3D.cpp
@@ -44,7 +44,7 @@ namespace ForgeEngine
         std::vector<Renderer3D::RenderItem> RenderQueue;
 
         // Mapping mesh+material -> items for efficient batching
-        std::unordered_map<std::string, std::vector<Renderer3D::RenderItem>>
+        std::unordered_map<MeshKey, std::vector<Renderer3D::RenderItem>>
         MeshBatches;
 
         // Reference to the InstancedRenderer
@@ -479,7 +479,7 @@ namespace ForgeEngine
         // Group items by mesh and material
         for (const auto& item : s_Data.RenderQueue)
         {
-            std::string meshKey = GetMeshKey(item.MeshPtr, item.MaterialPtr);
+            MeshKey meshKey{item.MeshPtr, item.MaterialPtr};
             s_Data.MeshBatches[meshKey].push_back(item);
         }
 
@@ -529,7 +529,7 @@ namespace ForgeEngine
         FENGINE_CORE_TRACE(
             "Rendered {} instances of mesh {} in single draw call",
             items.size(),
-            GetMeshKey(items[0].MeshPtr, items[0].MaterialPtr));
+            static_cast<const void*>(items[0].MeshPtr.get()));
 #endif
 
     }
@@ -557,13 +557,6 @@ namespace ForgeEngine
             && items.size() <= s_Data.InstanceRenderer->GetMaxInstances();
     }
 
-    std::string Renderer3D::GetMeshKey(Ref<Mesh> mesh, Ref<Material> material)
-    {
-        // Use mesh and material pointers as unique key
-        uintptr_t meshPtr = reinterpret_cast<uintptr_t>(mesh.get());
-        uintptr_t matPtr = reinterpret_cast<uintptr_t>(material.get());
-        return std::to_string(meshPtr) + "_" + std::to_string(matPtr);
-    }
 
     void Renderer3D::SubmitRenderItem(const RenderItem& item)
     {

--- a/ForgeEngine/Core/Renderer/Renderer3D.h
+++ b/ForgeEngine/Core/Renderer/Renderer3D.h
@@ -140,6 +140,18 @@ namespace ForgeEngine
         }
     };
 
+    struct MeshKey
+    {
+        Ref<Mesh> MeshPtr;
+        Ref<Material> MaterialPtr;
+
+        bool operator==(const MeshKey& other) const
+        {
+            return MeshPtr.get() == other.MeshPtr.get()
+                && MaterialPtr.get() == other.MaterialPtr.get();
+        }
+    };
+
     class Renderer3D
     {
     public:
@@ -272,7 +284,6 @@ namespace ForgeEngine
 
         // Helpers para agrupamento
         static bool ShouldUseInstancing(const std::vector<RenderItem>& items);
-        static std::string GetMeshKey(Ref<Mesh> mesh, Ref<Material> material);
 
         // Função helper para culling centralizado (mantida)
         friend bool PerformCulling(int entityID, const glm::mat4& transform,
@@ -283,3 +294,17 @@ namespace ForgeEngine
                                      Ref<Material> material, int entityID);
     };
 } // namespace ForgeEngine
+
+namespace std
+{
+    template <>
+    struct hash<ForgeEngine::MeshKey>
+    {
+        size_t operator()(const ForgeEngine::MeshKey& key) const noexcept
+        {
+            size_t h1 = std::hash<const void*>{}(key.MeshPtr.get());
+            size_t h2 = std::hash<const void*>{}(key.MaterialPtr.get());
+            return h1 ^ (h2 << 1);
+        }
+    };
+} // namespace std


### PR DESCRIPTION
## Summary
- introduce `MeshKey` with equality and hashing
- use `MeshKey` in Renderer3D batching map
- remove string-based batching key

## Testing
- `bash setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840c20d5cdc8332a954c7cdc1b00f35